### PR TITLE
await checkStreams

### DIFF
--- a/src/streamCall.ts
+++ b/src/streamCall.ts
@@ -1,10 +1,10 @@
-import {FluenceClient, registerServiceFunction} from "@fluencelabs/fluence";
-import {checkStreams} from "./compiled/stream";
+import { FluenceClient, registerServiceFunction } from "@fluencelabs/fluence";
+import { checkStreams } from "./compiled/stream";
 
 export async function streamCall(client: FluenceClient) {
     registerServiceFunction(client, "stringer-id", "returnString", (args: any[], _) => {
         return args[0] + " updated"
     })
 
-    return checkStreams(client, ["third", "fourth"])
+    return await checkStreams(client, ["third", "fourth"])
 }


### PR DESCRIPTION
address
`Error on sending particle with id 454b1603-2417-4372-89e7-3e5ec7a3e60b: Error: stream ended before 1 bytes became available`